### PR TITLE
Fix check for chunk_store in zarr backend

### DIFF
--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -417,7 +417,7 @@ class ZarrStore(AbstractWritableDataStore):
             if consolidated is None:
                 consolidated = False
 
-        if chunk_store:
+        if chunk_store is not None:
             open_kwargs["chunk_store"] = chunk_store
             if consolidated is None:
                 consolidated = False


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Zarr stores implement the `__len__` method and thus checking if a store is truthy returns if the store is non-empty, not if the `chunk_store` variable is still `None`. With this fix, empty stores can be passed as `chunk_store` to the `to_zarr(...)` method and will actually be used.

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
